### PR TITLE
Feature Request #15: Filtering Support for Appointments View

### DIFF
--- a/src/components/AppointmentFilter.tsx
+++ b/src/components/AppointmentFilter.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { useAppointmentStore } from '../lib/state/appointmentStore';
+
+export const AppointmentFilter: React.FC = () => {
+  const { patientFilter, setPatientFilter } = useAppointmentStore();
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPatientFilter(e.target.value || null);
+  };
+
+  return (
+    <div className="p-2">
+      <label htmlFor="patientFilter">Filter by patient:</label>
+      <input
+        id="patientFilter"
+        type="text"
+        value={patientFilter ?? ''}
+        onChange={handleChange}
+        className="border border-gray-300 rounded p-1 ml-2"
+      />
+    </div>
+  );
+};

--- a/src/features/appointments/AppointmentList.tsx
+++ b/src/features/appointments/AppointmentList.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { useAppointmentStore } from '../../lib/state/appointmentStore';
 import { AppointmentCard } from './AppointmentCard';
 import { Appointment } from '../../types/appointment';
+import { AppointmentFilter } from '../../components/AppointmentFilter';
 
 const AppointmentList: React.FC = () => {
   const { fetchAllAppointments, getAppointmentsByDate, isLoading, error } = useAppointmentStore();
@@ -19,6 +20,7 @@ const AppointmentList: React.FC = () => {
   return (
     <div>
       <h2>Today's Appointments</h2>
+      <AppointmentFilter />
       {todaysAppointments.length === 0 ? (
         <p>No appointments for today.</p>
       ) : (

--- a/src/features/appointments/WeeklyAppointmentList.tsx
+++ b/src/features/appointments/WeeklyAppointmentList.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { useAppointmentStore } from '../../lib/state/appointmentStore';
 import { DayColumn } from './DayColumn';
 import { startOfWeek, addDays } from 'date-fns';
+import { AppointmentFilter } from '../../components/AppointmentFilter';
 
 const WeeklyAppointmentList: React.FC = () => {
   const { fetchAllAppointments, getAppointmentsByDate, isLoading, error } = useAppointmentStore();
@@ -21,6 +22,8 @@ const WeeklyAppointmentList: React.FC = () => {
   return (
     <div>
       <h2>Weekly Appointments</h2>
+      <AppointmentFilter />
+
       <div style={{ display: 'flex', gap: '1rem' }}>
         {days.map(day => (
           <DayColumn key={day.toISOString()} date={day} appointments={getAppointmentsByDate(day)} />

--- a/src/lib/state/appointmentStore.ts
+++ b/src/lib/state/appointmentStore.ts
@@ -30,8 +30,12 @@ export const useAppointmentStore = create<AppointmentStore>((set, get) => ({
     try {
       const data = await fetchAppointments();
       set({ appointments: data, isLoading: false });
-    } catch (err: any) {
-      set({ error: err.message || 'Failed to fetch appointments', isLoading: false });
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        set({ error: err.message, isLoading: false });
+      } else {
+        set({ error: 'Failed to fetch appointments', isLoading: false });
+      }
     }
   },
 
@@ -39,7 +43,7 @@ export const useAppointmentStore = create<AppointmentStore>((set, get) => ({
     const appointments = get().appointments;
     const patientFilter = get().patientFilter;
 
-    return appointments.filter((appt) => {
+    return appointments.filter(appt => {
       const apptDate = parseISO(appt.time);
       const dateMatch =
         apptDate.getFullYear() === date.getFullYear() &&
@@ -60,7 +64,7 @@ export const useAppointmentStore = create<AppointmentStore>((set, get) => ({
     const weekEnd = new Date(weekStart);
     weekEnd.setDate(weekStart.getDate() + 7);
 
-    return appointments.filter((appt) => {
+    return appointments.filter(appt => {
       const apptDate = parseISO(appt.time);
       const inWeek = apptDate >= weekStart && apptDate < weekEnd;
 

--- a/tests/integration/Filtering.integration.test.tsx
+++ b/tests/integration/Filtering.integration.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import WeeklyAppointmentList from '../../src/features/appointments/WeeklyAppointmentList';
+import { AppointmentFilter } from '../../src/components/AppointmentFilter';
+
+jest.mock('../../src/lib/api/client', () => {
+  // Inlining mock data to avoid hoisting issues.
+  return {
+    fetchAppointments: jest.fn().mockResolvedValue([
+      { id: '1', patientName: 'Alice Johnson', time: '2025-06-10T09:00:00Z', status: 'completed' },
+      { id: '2', patientName: 'Bob Smith', time: '2025-06-10T10:30:00Z', status: 'upcoming' },
+      { id: '3', patientName: 'Carol White', time: '2025-06-12T13:00:00Z', status: 'cancelled' },
+    ]),
+  };
+});
+
+describe('Filtering integration', () => {
+  it('filters by patient name', async () => {
+    render(
+      <>
+        <AppointmentFilter />
+        <WeeklyAppointmentList />
+      </>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice Johnson')).toBeInTheDocument();
+    });
+
+    const input = screen.getByLabelText(/filter by patient/i);
+    fireEvent.change(input, { target: { value: 'Alice' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice Johnson')).toBeInTheDocument();
+      expect(screen.queryByText('Bob Smith')).toBeNull();
+      expect(screen.queryByText('Carol White')).toBeNull();
+    });
+  });
+});

--- a/tests/integration/WeeklyAppointmentList.integration.test.tsx
+++ b/tests/integration/WeeklyAppointmentList.integration.test.tsx
@@ -68,4 +68,12 @@ describe('WeeklyAppointmentList', () => {
 
     expect(screen.getAllByText(/No appointments/i).length).toBe(7);
   });
+
+  it('renders error message when error is present', () => {
+    // Mock fetchAllAppointments to do nothing
+    jest.spyOn(useAppointmentStore.getState(), 'fetchAllAppointments').mockImplementation(() => Promise.resolve());
+    useAppointmentStore.setState({ appointments: [], error: 'Something went wrong', isLoading: false });
+    render(<WeeklyAppointmentList />);
+    expect(screen.getByText(/Error: Something went wrong/)).toBeInTheDocument();
+  });
 });

--- a/tests/unit/components/AppointmentFilter.test.tsx
+++ b/tests/unit/components/AppointmentFilter.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AppointmentFilter } from '../../../src/components/AppointmentFilter';
+import { useAppointmentStore } from '../../../src/lib/state/appointmentStore';
+
+jest.mock('../../../src/lib/state/appointmentStore', () => ({
+  useAppointmentStore: jest.fn(),
+}));
+
+describe('AppointmentFilter', () => {
+  it('renders input with value from store', () => {
+    ((useAppointmentStore as unknown) as jest.Mock).mockReturnValue({
+      patientFilter: 'Alice',
+      setPatientFilter: jest.fn(),
+    });
+    render(<AppointmentFilter />);
+    expect(screen.getByDisplayValue('Alice')).toBeInTheDocument();
+  });
+
+  it('calls setPatientFilter on input change', () => {
+    const setPatientFilter = jest.fn();
+    ((useAppointmentStore as unknown) as jest.Mock).mockReturnValue({
+      patientFilter: '',
+      setPatientFilter,
+    });
+    render(<AppointmentFilter />);
+    fireEvent.change(screen.getByLabelText(/filter by patient/i), { target: { value: 'Bob' } });
+    expect(setPatientFilter).toHaveBeenCalledWith('Bob');
+  });
+
+  it('clears the filter when input is cleared', () => {
+    const setPatientFilter = jest.fn();
+    ((useAppointmentStore as unknown) as jest.Mock).mockReturnValue({
+      patientFilter: 'Alice',
+      setPatientFilter,
+    });
+    render(<AppointmentFilter />);
+    fireEvent.change(screen.getByLabelText(/filter by patient/i), { target: { value: '' } });
+    expect(setPatientFilter).toHaveBeenCalledWith(null);
+  });
+
+  it('handles undefined patientFilter gracefully', () => {
+    ((useAppointmentStore as unknown) as jest.Mock).mockReturnValue({
+      patientFilter: undefined,
+      setPatientFilter: jest.fn(),
+    });
+    render(<AppointmentFilter />);
+    expect(screen.getByLabelText(/filter by patient/i)).toHaveValue('');
+  });
+}); 

--- a/tests/unit/features/appointments/AppointmentList.test.tsx
+++ b/tests/unit/features/appointments/AppointmentList.test.tsx
@@ -53,4 +53,12 @@ describe('AppointmentList', () => {
       expect(screen.getByText('No appointments for today.')).toBeInTheDocument();
     });
   });
+
+  it('renders error message when error is present', () => {
+    // Mock fetchAllAppointments to do nothing
+    jest.spyOn(useAppointmentStore.getState(), 'fetchAllAppointments').mockImplementation(() => Promise.resolve());
+    useAppointmentStore.setState({ appointments: [], error: 'Something went wrong', isLoading: false });
+    render(<AppointmentList />);
+    expect(screen.getByText(/Error: Something went wrong/)).toBeInTheDocument();
+  });
 });

--- a/tests/unit/state/appointmentStore.test.ts
+++ b/tests/unit/state/appointmentStore.test.ts
@@ -38,4 +38,67 @@ describe('appointmentStore', () => {
     const weeklyAppointments = useAppointmentStore.getState().getAppointmentsForWeek(weekStart);
     expect(weeklyAppointments).toHaveLength(3);
   });
+
+  it('sets error when fetchAppointments throws', async () => {
+    const errorMessage = 'Network error';
+    jest.spyOn(clientApi, 'fetchAppointments').mockRejectedValue(new Error(errorMessage));
+    useAppointmentStore.setState({ appointments: [], error: null, isLoading: false });
+
+    await useAppointmentStore.getState().fetchAllAppointments();
+    const state = useAppointmentStore.getState();
+    expect(state.error).toBe(errorMessage);
+    expect(state.isLoading).toBe(false);
+  });
+
+  it('filters by patient name in getAppointmentsByDate', () => {
+    useAppointmentStore.setState({ appointments: mockAppointments, patientFilter: 'Alice' });
+    const filtered = useAppointmentStore.getState().getAppointmentsByDate(tuesday);
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].patientName).toBe('Alice Johnson');
+  });
+
+  it('filters by patient name in getAppointmentsForWeek', () => {
+    useAppointmentStore.setState({ appointments: mockAppointments, patientFilter: 'Carol' });
+    const filtered = useAppointmentStore.getState().getAppointmentsForWeek(weekStart);
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].patientName).toBe('Carol White');
+  });
+
+  it('returns empty array if patientFilter does not match any name in getAppointmentsByDate', () => {
+    useAppointmentStore.setState({ appointments: mockAppointments, patientFilter: 'Nonexistent' });
+    const filtered = useAppointmentStore.getState().getAppointmentsByDate(tuesday);
+    expect(filtered).toHaveLength(0);
+  });
+
+  it('treats empty string patientFilter as no filter in getAppointmentsByDate', () => {
+    useAppointmentStore.setState({ appointments: mockAppointments, patientFilter: '' });
+    const filtered = useAppointmentStore.getState().getAppointmentsByDate(tuesday);
+    expect(filtered).toHaveLength(2);
+  });
+
+  it('treats undefined patientFilter as no filter in getAppointmentsByDate', () => {
+    useAppointmentStore.setState({ appointments: mockAppointments, patientFilter: undefined });
+    const filtered = useAppointmentStore.getState().getAppointmentsByDate(tuesday);
+    expect(filtered).toHaveLength(2);
+  });
+
+  it('handles appointments with empty patientName', () => {
+    const appointmentsWithEmptyName: Appointment[] = [
+      ...mockAppointments,
+      { id: '4', patientName: '', time: `${tuesday.toISOString().split('T')[0]}T12:00:00Z`, status: 'upcoming' },
+    ];
+    useAppointmentStore.setState({ appointments: appointmentsWithEmptyName, patientFilter: '' });
+    const filtered = useAppointmentStore.getState().getAppointmentsByDate(tuesday);
+    expect(filtered.length).toBeGreaterThanOrEqual(2); // Should include the empty name appointment
+  });
+
+  it('sets default error message if error has no message', async () => {
+    jest.spyOn(clientApi, 'fetchAppointments').mockRejectedValue({});
+    useAppointmentStore.setState({ appointments: [], error: null, isLoading: false });
+
+    await useAppointmentStore.getState().fetchAllAppointments();
+    const state = useAppointmentStore.getState();
+    expect(state.error).toBe('Failed to fetch appointments');
+    expect(state.isLoading).toBe(false);
+  });
 });


### PR DESCRIPTION
## 🚀 Summary

<!-- Briefly describe what this PR does -->

- Implements: #15 
- Scope: Implements the first stage of filtering functionality for both Daily and Weekly appointment views, starting with Patient Name filtering.

---

## 📄 Description

<!-- Provide a short description of the changes -->
#### Principal Changes
- ✅ Added patient filtering capability to `appointmentStore` using centralized Zustand state management.
- ✅ Added `setPatientFilter()` and selector updates to dynamically filter appointments by patient name.
- ✅ Created new `AppointmentFilter` component to control filter input state.
- ✅ Wired filter component into both Daily and Weekly views to apply live filtering logic.
- ✅ Filtering logic operates entirely client-side for now, designed to be backend-query compatible in the future.
- ✅ Used Tailwind CSS utility classes to scaffold lightweight UI for filter control.
- ✅ Fully exercised filtering logic via integration tests.
- ✅ Applied disciplined Jest mocking practices:
  - Inline test mock data to avoid hoisting issues.
  - Use of `jest.requireActual()` when helper libraries (e.g. `date-fns`) are required inside mocks.
- ✅ Test pyramid remains fully stable under CI pipeline.

 #### Tech Improvement Changes
- ✅ I took this opportunity to address some partial coverage concerns on three classes that were modified for this ticket:
  - src/features/appointments/AppointmentList.tsx
  - src/features/appointments/WeeklyAppointmentList.tsx
  - src/lib/state/appointmentStore.ts

---

## 🧪 Test Coverage

- [x] Unit tests passing
- [x] Integration tests passing
- [ ] E2E tests (if applicable)
- [ ] Accessibility tests (if applicable)

---

## ✅ Checklist

- [x] Code builds locally (`npm run dev`)
- [x] Tests passing (`npm test`)
- [x] Code formatted (`npm run format`)
- [x] Lint clean (`npm run lint`)
- [x] No sensitive data committed

---

## 📸 Screenshots / Demo (optional)

<!-- If applicable, include screenshots or a Loom link -->
### Weekly and Daily List Components
#### BEFORE:
![image](https://github.com/user-attachments/assets/9909153d-2421-45a1-9af9-8ec61d320f49)

#### AFTER:
![image](https://github.com/user-attachments/assets/4a5fa2c0-de03-4204-842e-de1de60458cc)

### Test Results
#### Coverage Report
![image](https://github.com/user-attachments/assets/99133fe0-125c-4906-aae8-7172b31ab411)

#### Test Run
```
> care-coordination-dashboard@1.0.0 test
> jest --coverage




 PASS  tests/unit/features/appointments/AppointmentCard.test.tsx
 PASS  tests/unit/components/AppointmentFilter.test.tsx
 PASS  tests/unit/state/appointmentStore.test.ts
 PASS  tests/unit/features/appointments/DayColumn.test.tsx
 PASS  tests/unit/features/appointments/AppointmentList.test.tsx
 PASS  tests/unit/lib/api/client.test.ts
 PASS  tests/integration/WeeklyAppointmentList.integration.test.tsx
 PASS  tests/integration/Filtering.integration.test.tsx
 PASS  tests/integration/Dashboard.integration.test.tsx
----------------------------|---------|----------|---------|---------|-------------------
File                        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------------------------|---------|----------|---------|---------|-------------------
All files                   |     100 |      100 |     100 |     100 |                   
 components                 |     100 |      100 |     100 |     100 |                   
  AppointmentFilter.tsx     |     100 |      100 |     100 |     100 |                   
 features/appointments      |     100 |      100 |     100 |     100 |                   
  AppointmentCard.tsx       |     100 |      100 |     100 |     100 |                   
  AppointmentList.tsx       |     100 |      100 |     100 |     100 |                   
  DayColumn.tsx             |     100 |      100 |     100 |     100 |                   
  WeeklyAppointmentList.tsx |     100 |      100 |     100 |     100 |                   
 lib/api                    |     100 |      100 |     100 |     100 |                   
  client.ts                 |     100 |      100 |     100 |     100 |                   
 lib/state                  |     100 |      100 |     100 |     100 |                   
  appointmentStore.ts       |     100 |      100 |     100 |     100 |                   
----------------------------|---------|----------|---------|---------|-------------------

Test Suites: 9 passed, 9 total
Tests:       34 passed, 34 total
Snapshots:   0 total
Time:        7.156 s
Ran all test suites.
```

---

## 🔗 Related Issues

- Closes #15 

---

## 🙏 Reviewer Notes

<!-- Any special notes for reviewers -->


